### PR TITLE
Constructor should not return anything. Just call parent ctor

### DIFF
--- a/src/BeSimple/WsdlToPhp/ClientGenerator.php
+++ b/src/BeSimple/WsdlToPhp/ClientGenerator.php
@@ -115,7 +115,7 @@ class ClientGenerator extends AbstractClassGenerator
         $lines[] = $this->spaces . $this->spaces . $this->spaces . '$options[\'classmap\'] = $this->getClassMap();';
         $lines[] = $this->spaces . $this->spaces . '}';
         $lines[] = '';
-        $lines[] = $this->spaces . $this->spaces . 'return parent::__construct($wsdl, $options);';
+        $lines[] = $this->spaces . $this->spaces . 'parent::__construct($wsdl, $options);';
         $lines[] = $this->spaces . '}';
         $lines[] = '';
         $lines[] = $this->spaces . 'public function getClassMap()';

--- a/src/BeSimple/WsdlToPhp/Tests/Fixtures/My/Webservices/Client.php
+++ b/src/BeSimple/WsdlToPhp/Tests/Fixtures/My/Webservices/Client.php
@@ -32,7 +32,7 @@ class Client extends BaseSoapClient
             $options['classmap'] = $this->getClassMap();
         }
 
-        return parent::__construct($wsdl, $options);
+        parent::__construct($wsdl, $options);
     }
 
     public function getClassMap()


### PR DESCRIPTION
I know it is 'just' generated code and it won't actually harm in any way, but it makes a lot of bells and whistles go off. And I don't like it when that happens.

This PR removes the 'return' from the constructor in the client, which is unnecessary.