### PR TITLE
Feature/warning free generation

### DIFF
--- a/src/BeSimple/WsdlToPhp/WsdlParser.php
+++ b/src/BeSimple/WsdlToPhp/WsdlParser.php
@@ -274,12 +274,22 @@ class WsdlParser
         foreach ($inputTypeWsdl['properties'] as $property) {
             $parameters[$property['name']] = $property['phpType'];
         }
-        if (isset($inputTypeWsdl['parent'])) {
+        if (isset($inputTypeWsdl['parent']) && !$this->isSelfParent($inputTypeWsdl)) {
             $inputTypeNS = $inputTypeWsdl['parentXml'];
             $parameters = array_merge($parameters, $this->getOperationParameters($wsdlTypes, $inputTypeNS));
         }
 
         return $parameters;
+    }
+
+    private function isSelfParent($wsdlTypes)
+    {
+        if (!isset($wsdlTypes['namespace'], $wsdlTypes['name'], $wsdlTypes['parent'])) {
+            return false;
+        }
+        $selfFqn = $wsdlTypes['namespace'] . '\\' . $wsdlTypes['name'];
+
+        return $selfFqn === $wsdlTypes['parent'];
     }
 
     /**

--- a/src/BeSimple/WsdlToPhp/WsdlParser.php
+++ b/src/BeSimple/WsdlToPhp/WsdlParser.php
@@ -358,11 +358,6 @@ class WsdlParser
     protected function addNewTypeIntoList(&$typeList, $newTypeName, $newType)
     {
         if (!empty($typeList[$newTypeName])) {
-            $this->addError(
-                "Type: '{$newTypeName}' in file '{$newType['wsdl']}' already exist",
-                0,
-                $typeList[$newTypeName]['wsdl']
-            );
             $typeList[$newTypeName] = $this->arrayMergeRecursive(
                 $typeList[$newTypeName],
                 $newType


### PR DESCRIPTION
The error that was generated when a type already exists is unnecessary: https://www.w3.org/TR/xmlschema-1/#concepts-nameSymbolSpaces

> For example, the same name can appear in both a type definition and an element declaration, without conflict or necessary relation between the two

When generating my client I got this error:
> Warning: Invalid argument supplied for foreach() in src/BeSimple/WsdlToPhp/WsdlParser.php on line 274

This was because the parent referred to the same element. I added a check to fix that.